### PR TITLE
A slight bit more consistent usage of ::std::os::raw::c_char type

### DIFF
--- a/src/linux/request.rs
+++ b/src/linux/request.rs
@@ -61,7 +61,7 @@ impl ifreq {
     pub fn new(name: &str) -> Self {
         let mut req: ifreq = unsafe { mem::zeroed() };
         if !name.is_empty() {
-            let mut ifname: [i8; IFNAMSIZ as _] = [0; IFNAMSIZ as _];
+            let mut ifname: [::std::os::raw::c_char; IFNAMSIZ as _] = [0; IFNAMSIZ as _];
             for (i, c) in name.as_bytes().iter().enumerate() {
                 if i > ifname.len() - 1 {
                     break;


### PR DESCRIPTION
It seems like the representation of `c_char` is different for linux@arm and linux@x64-64 