### PR TITLE
perf(tun) allow concurrent access to the Tun object

### DIFF
--- a/src/linux/io.rs
+++ b/src/linux/io.rs
@@ -24,21 +24,13 @@ impl AsRawFd for TunIo {
 
 impl Read for TunIo {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let n = unsafe { libc::read(self.0, buf.as_ptr() as *mut _, buf.len() as _) };
-        if n < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(n as _)
+        self.recv(buf)
     }
 }
 
 impl Write for TunIo {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let n = unsafe { libc::write(self.0, buf.as_ptr() as *const _, buf.len() as _) };
-        if n < 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(n as _)
+        self.send(buf)
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -47,6 +39,24 @@ impl Write for TunIo {
             return Err(io::Error::last_os_error());
         }
         Ok(())
+    }
+}
+
+impl TunIo {
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = unsafe { libc::read(self.0, buf.as_ptr() as *mut _, buf.len() as _) };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(n as _)
+    }
+
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        let n = unsafe { libc::write(self.0, buf.as_ptr() as *const _, buf.len() as _) };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(n as _)
     }
 }
 

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -148,6 +148,24 @@ impl Tun {
         }
     }
 
+    /// Try to receive a packet from the Tun/Tap interface
+    ///
+    /// When there is no pending data, `Err(io::ErrorKind::WouldBlock)` is returned.
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub fn try_recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.get_ref().recv(buf)
+    }
+
+    /// Try to send a packet to the Tun/Tap interface
+    ///
+    /// When the socket buffer is full, `Err(io::ErrorKind::WouldBlock)` is returned.
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub fn try_send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.io.get_ref().send(buf)
+    }
+
     /// Returns the name of Tun/Tap device.
     pub fn name(&self) -> &str {
         self.iface.name()


### PR DESCRIPTION
Tun/Tap fds, like UDP socket, are fully capable of concurrent access. This PR adds new methods `recv()` and `send()` as well as `try_recv()`, `try_send()` to the `Tun` struct that takes in `&self` instead of `&mut self`, allowing such access.

See: https://docs.rs/tokio/1.11.0/tokio/net/struct.UdpSocket.html#method.send
https://docs.rs/tokio/1.11.0/tokio/net/struct.UdpSocket.html#method.try_send
https://github.com/cloudflare/boringtun/blob/master/src/device/tun_linux.rs#L68-L75