### PR TITLE
Implement IPv6 support

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -18,6 +18,7 @@ pub struct TunBuilder<'a> {
     owner: Option<i32>,
     group: Option<i32>,
     address: Option<IpAddr>,
+    prefix_length: u32,
     destination: Option<Ipv4Addr>,
     broadcast: Option<Ipv4Addr>,
     netmask: Option<Ipv4Addr>,
@@ -35,6 +36,7 @@ impl<'a> Default for TunBuilder<'a> {
             mtu: None,
             packet_info: true,
             address: None,
+            prefix_length: 128,
             destination: None,
             broadcast: None,
             netmask: None,
@@ -87,6 +89,15 @@ impl<'a> TunBuilder<'a> {
     /// Sets IPv4 address of device.
     pub fn address(mut self, address: IpAddr) -> Self {
         self.address = Some(address);
+        self
+    }
+
+    /// Sets the IPv6 prefix length
+    ///
+    /// This is only useful when setting an IPv6 address via [`TunBuilder::address()`] because only IPv6 addresses
+    /// have the concept of prefixes. If IPv4 is used, call [`TunBuilder::netmask()`] instead.
+    pub fn prefix_length(mut self, prefix_length: u32) -> Self {
+        self.prefix_length = prefix_length;
         self
     }
 
@@ -154,6 +165,7 @@ impl<'a> From<TunBuilder<'a>> for Params {
             owner: builder.owner,
             group: builder.group,
             address: builder.address,
+            prefix_length: builder.prefix_length,
             destination: builder.destination,
             broadcast: builder.broadcast,
             netmask: builder.netmask,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,7 +5,7 @@ use crate::linux::params::Params;
 use crate::tun::Tun;
 use core::convert::From;
 use libc::{IFF_NO_PI, IFF_TAP, IFF_TUN};
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, IpAddr};
 
 /// Represents a factory to build new instances of [`Tun`](struct.Tun.html).
 pub struct TunBuilder<'a> {
@@ -17,7 +17,7 @@ pub struct TunBuilder<'a> {
     mtu: Option<i32>,
     owner: Option<i32>,
     group: Option<i32>,
-    address: Option<Ipv4Addr>,
+    address: Option<IpAddr>,
     destination: Option<Ipv4Addr>,
     broadcast: Option<Ipv4Addr>,
     netmask: Option<Ipv4Addr>,
@@ -85,7 +85,7 @@ impl<'a> TunBuilder<'a> {
     }
 
     /// Sets IPv4 address of device.
-    pub fn address(mut self, address: Ipv4Addr) -> Self {
+    pub fn address(mut self, address: IpAddr) -> Self {
         self.address = Some(address);
         self
     }
@@ -142,7 +142,7 @@ impl<'a> From<TunBuilder<'a>> for Params {
                 Some(builder.name.into())
             },
             flags: {
-                let mut flags = if builder.is_tap { IFF_TAP } else { IFF_TUN } as _;
+                let mut flags: i16 = if builder.is_tap { IFF_TAP } else { IFF_TUN } as _;
                 if !builder.packet_info {
                     flags |= IFF_NO_PI as i16;
                 }

--- a/src/linux/address.rs
+++ b/src/linux/address.rs
@@ -1,10 +1,17 @@
-use super::request::sockaddr;
+use super::request::{sockaddr, in6_addr};
 use std::mem;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
+/// A utility trait used to convert between rust and C IPv4 address representations
 pub trait Ipv4AddrExt {
     fn to_address(&self) -> sockaddr;
     fn from_address(sock: sockaddr) -> Self;
+}
+
+/// A utility trait used to convert between rust and C IPv6 address representations
+pub trait Ipv6AddrExt {
+    fn to_address(&self) -> in6_addr;
+    fn from_address(address: in6_addr) -> Self;
 }
 
 fn hton(octets: [u8; 4]) -> u32 {
@@ -34,5 +41,17 @@ impl Ipv4AddrExt for Ipv4Addr {
     fn from_address(addr: sockaddr) -> Self {
         let sock: libc::sockaddr_in = unsafe { mem::transmute(addr) };
         ntoh(sock.sin_addr.s_addr).into()
+    }
+}
+
+impl Ipv6AddrExt for Ipv6Addr {
+    fn to_address(&self) -> in6_addr {
+        in6_addr {
+            s6_addr: self.octets(),
+        }
+    }
+
+    fn from_address(address: in6_addr) -> Self {
+        Self::from(address.s6_addr)
     }
 }

--- a/src/linux/interface.rs
+++ b/src/linux/interface.rs
@@ -171,6 +171,12 @@ impl Interface {
         }
         Ok(())
     }
+
+    pub fn index(&self) -> Result<::std::os::raw::c_int> {
+        let mut req = ifreq::new(self.name());
+        unsafe { siocgifindex(self.socket, &mut req) }?;
+        Ok(unsafe { req.ifr_ifru.ifru_ifindex })
+    }
 }
 
 impl Drop for Interface {

--- a/src/linux/interface.rs
+++ b/src/linux/interface.rs
@@ -1,8 +1,9 @@
 use super::params::Params;
-use super::request::ifreq;
-use crate::linux::address::Ipv4AddrExt;
+use super::request::{ifreq, in6_ifreq, in6_addr};
+use crate::linux::address::{Ipv4AddrExt, Ipv6AddrExt};
 use crate::result::Result;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use nix::errno::Errno::EADDRNOTAVAIL;
 
 nix::ioctl_write_int!(tunsetiff, b'T', 202);
 nix::ioctl_write_int!(tunsetpersist, b'T', 203);
@@ -12,6 +13,7 @@ nix::ioctl_write_int!(tunsetgroup, b'T', 206);
 nix::ioctl_write_ptr_bad!(siocsifmtu, libc::SIOCSIFMTU, ifreq);
 nix::ioctl_write_ptr_bad!(siocsifflags, libc::SIOCSIFFLAGS, ifreq);
 nix::ioctl_write_ptr_bad!(siocsifaddr, libc::SIOCSIFADDR, ifreq);
+nix::ioctl_write_ptr_bad!(siocsifaddr6, libc::SIOCSIFADDR, in6_ifreq);
 nix::ioctl_write_ptr_bad!(siocsifdstaddr, libc::SIOCSIFDSTADDR, ifreq);
 nix::ioctl_write_ptr_bad!(siocsifbrdaddr, libc::SIOCSIFBRDADDR, ifreq);
 nix::ioctl_write_ptr_bad!(siocsifnetmask, libc::SIOCSIFNETMASK, ifreq);
@@ -22,11 +24,13 @@ nix::ioctl_read_bad!(siocgifaddr, libc::SIOCGIFADDR, ifreq);
 nix::ioctl_read_bad!(siocgifdstaddr, libc::SIOCGIFDSTADDR, ifreq);
 nix::ioctl_read_bad!(siocgifbrdaddr, libc::SIOCGIFBRDADDR, ifreq);
 nix::ioctl_read_bad!(siocgifnetmask, libc::SIOCGIFNETMASK, ifreq);
+nix::ioctl_read_bad!(siocgifindex, 0x8933, ifreq);
 
 #[derive(Clone)]
 pub struct Interface {
     fds: Vec<i32>,
     socket: i32,
+    socket6: i32,
     name: String,
 }
 
@@ -43,6 +47,7 @@ impl Interface {
         Ok(Interface {
             fds,
             socket: unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) },
+            socket6: unsafe { libc::socket(libc::AF_INET6, libc::SOCK_DGRAM, 0) },
             name: req.name(),
         })
     }
@@ -108,15 +113,35 @@ impl Interface {
         Ok(unsafe { Ipv4Addr::from_address(req.ifr_ifru.ifru_netmask) })
     }
 
-    pub fn address(&self, address: Option<Ipv4Addr>) -> Result<Ipv4Addr> {
-        let mut req = ifreq::new(self.name());
-        if let Some(address) = address {
-            req.ifr_ifru.ifru_addr = address.to_address();
-            unsafe { siocsifaddr(self.socket, &req) }?;
-            return Ok(address);
+    pub fn address(&self, address: Option<IpAddr>) -> Result<IpAddr> {
+        match address {
+            None => {
+                // TODO handle IPv6 addresses
+                // This is non-trivial because ioctl will only ever return IPv4 addresses
+                let mut req = ifreq::new(self.name());
+                unsafe { siocgifaddr(self.socket, &mut req) }?;
+                Ok(unsafe { IpAddr::V4(Ipv4Addr::from_address(req.ifr_ifru.ifru_addr)) })
+            }
+            Some(address) => {
+                match address {
+                    IpAddr::V4(address) => {
+                        let mut req = ifreq::new(self.name());
+                        req.ifr_ifru.ifru_addr = address.to_address();
+                        unsafe { siocsifaddr(self.socket, &req) }?;
+                        Ok(IpAddr::V4(address))
+                    }
+                    IpAddr::V6(address) => {
+                        let req = in6_ifreq {
+                            ifr6_ifindex: self.index()?,
+                            ifr6_prefixlen: 128,
+                            ifr6_addr: address.to_address(),
+                        };
+                        unsafe { siocsifaddr6(self.socket6, &req) }?;
+                        Ok(IpAddr::V6(address))
+                    }
+                }
+            }
         }
-        unsafe { siocgifaddr(self.socket, &mut req) }?;
-        Ok(unsafe { Ipv4Addr::from_address(req.ifr_ifru.ifru_addr) })
     }
 
     pub fn destination(&self, dst: Option<Ipv4Addr>) -> Result<Ipv4Addr> {

--- a/src/linux/params.rs
+++ b/src/linux/params.rs
@@ -11,6 +11,7 @@ pub struct Params {
     pub owner: Option<i32>,
     pub group: Option<i32>,
     pub address: Option<IpAddr>,
+    pub prefix_length: u32,
     pub destination: Option<Ipv4Addr>,
     pub broadcast: Option<Ipv4Addr>,
     pub netmask: Option<Ipv4Addr>,

--- a/src/linux/params.rs
+++ b/src/linux/params.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 
 /// Represents parameters for creating a new Tun/Tap device on Linux.
 #[cfg(target_os = "linux")]
@@ -10,7 +10,7 @@ pub struct Params {
     pub mtu: Option<i32>,
     pub owner: Option<i32>,
     pub group: Option<i32>,
-    pub address: Option<Ipv4Addr>,
+    pub address: Option<IpAddr>,
     pub destination: Option<Ipv4Addr>,
     pub broadcast: Option<Ipv4Addr>,
     pub netmask: Option<Ipv4Addr>,

--- a/src/linux/request.rs
+++ b/src/linux/request.rs
@@ -9,9 +9,20 @@ const IFNAMSIZ: u32 = 16;
 
 #[repr(C)]
 #[derive(Copy, Clone)]
+/// Network interface ioctl request
+///
+/// See [man netdevice(7)](https://man7.org/linux/man-pages/man7/netdevice.7.html)
 pub struct ifreq {
     pub ifr_ifrn: ifreq_ifrn,
     pub ifr_ifru: ifreq_ifru,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct in6_ifreq {
+    pub ifr6_addr: in6_addr,
+    pub ifr6_prefixlen: ::std::os::raw::c_uint,
+    pub ifr6_ifindex: ::std::os::raw::c_int,
 }
 
 #[repr(C)]
@@ -30,6 +41,7 @@ pub union ifreq_ifru {
     pub ifru_netmask: sockaddr,
     pub ifru_hwaddr: sockaddr,
     pub ifru_flags: ::std::os::raw::c_short,
+    pub ifru_ifindex: ::std::os::raw::c_int,
     pub ifru_ivalue: ::std::os::raw::c_int,
     pub ifru_mtu: ::std::os::raw::c_int,
     pub ifru_map: ifmap,
@@ -41,10 +53,17 @@ pub union ifreq_ifru {
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+/// Linux kernel IPv4 socket address representation
+///
+/// See [man ip(7)](https://man7.org/linux/man-pages/man7/ip.7.html)
 pub struct sockaddr {
+    // see https://man7.org/linux/man-pages/man7/ip.7.html for docs
     pub sa_family: ::std::os::raw::c_ushort,
     pub sa_data: [::std::os::raw::c_char; 14usize],
 }
+
+// See https://man7.org/linux/man-pages/man7/ipv6.7.html
+pub type in6_addr = libc::in6_addr;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -132,7 +132,7 @@ impl Tun {
 
     /// Returns the IPv4 address of MTU.
     pub fn address(&self) -> Result<IpAddr> {
-        self.iface.address(None)
+        self.iface.address(None, 0)
     }
 
     /// Returns the IPv4 destination address of MTU.

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -6,7 +6,7 @@ use futures::ready;
 use std::ffi::CString;
 use std::io;
 use std::io::{Read, Write};
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -131,7 +131,7 @@ impl Tun {
     }
 
     /// Returns the IPv4 address of MTU.
-    pub fn address(&self) -> Result<Ipv4Addr> {
+    pub fn address(&self) -> Result<IpAddr> {
         self.iface.address(None)
     }
 


### PR DESCRIPTION
This is my approach to implementing IPv6 support.

It is fairly minimal at the moment and I will try to keep the following checklist up to date on what is already implemented:
- [x] Set the interfaces own address as IPv6
- [x] Specify the IPv6 adresses prefix length in `TunBuilder`
- [ ] Retrieving IPv6 addresses from `Tun` instances.
      This is requires changing the currently used syscall from *ioctl* to *getifaddrs* because *ioctl* will only ever return IPv4 addresses.

Known inconveniences:
- When the user specifies an IPv6 address as well as a netmask, an `EADDRNOTAVAIL: Cannot assign requested address` gets thrown upon building the TUN device.
  We should think about whether we want to just keep it that way or return our own error that then explicitly tells the user what they did wrong.

As always, feel free to give feedback :)

closes #6 

