### PR TITLE
Drop dependency on the futures crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ keywords = ["tun", "tap", "async", "tokio"]
 tokio = { version = "1.18", features = ["net"] }
 libc = "0.2"
 nix = { version = "0.24", default-features = false, features = ["ioctl"] }
-futures = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.18", features = ["full"] }

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -2,7 +2,6 @@ use crate::linux::interface::Interface;
 use crate::linux::io::TunIo;
 use crate::linux::params::Params;
 use crate::result::Result;
-use futures::ready;
 use std::ffi::CString;
 use std::io;
 use std::io::{Read, Write};
@@ -13,6 +12,16 @@ use std::sync::Arc;
 use std::task::{self, Context, Poll};
 use tokio::io::unix::AsyncFd;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+// Taken from the `futures` crate
+macro_rules! ready {
+    ($e:expr $(,)?) => {
+        match $e {
+            std::task::Poll::Ready(t) => t,
+            std::task::Poll::Pending => return std::task::Poll::Pending,
+        }
+    };
+}
 
 /// Represents a Tun/Tap device. Use [`TunBuilder`](struct.TunBuilder.html) to create a new instance of [`Tun`](struct.Tun.html).
 pub struct Tun {


### PR DESCRIPTION
Considering how heavy the `futures` crate is I don't think it's worth importing it just for the `ready` macro. This inlines it instead.