### PR TITLE
use c_char when appropriate

### DIFF
--- a/src/linux/request.rs
+++ b/src/linux/request.rs
@@ -67,7 +67,7 @@ impl ifreq {
             let name = &name[..len];
             unsafe {
                 ptr::copy_nonoverlapping(
-                    name.as_ptr().cast::<i8>(),
+                    name.as_ptr().cast::<::std::os::raw::c_char>(),
                     req.ifr_ifrn.ifrn_name.as_mut_ptr(),
                     len,
                 );

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -120,7 +120,10 @@ impl Tun {
 
         let fds = (0..queues)
             .map(|_| unsafe {
-                libc::open(TUN.as_ptr().cast::<i8>(), libc::O_RDWR | libc::O_NONBLOCK)
+                libc::open(
+                    TUN.as_ptr().cast::<::std::os::raw::c_char>(),
+                    libc::O_RDWR | libc::O_NONBLOCK,
+                )
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
Got a couple of errors when compiling v0.6.0 for target `arm-poky-linux-gnueabi` (see below).
Seems to come from the use of i8/u8 instead of c_char for some calls. And that the actual type of [c_char](https://doc.rust-lang.org/std/os/raw/type.c_char.html) may differ between architectures. This PR should fix this.

```shell
     |
69   |                 ptr::copy_nonoverlapping(
     |                 ------------------------ arguments to this function are incorrect
70   |                     name.as_ptr().cast::<i8>(),
71   |                     req.ifr_ifrn.ifrn_name.as_mut_ptr(),
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i8`, found `u8`
     |
     = note: expected raw pointer `*mut i8`
                found raw pointer `*mut u8`
...
    |
123 |                 libc::open(TUN.as_ptr().cast::<i8>(), libc::O_RDWR | libc::O_NONBLOCK)
    |                 ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |                 |
    |                 arguments to this function are incorrect
    |
    = note: expected raw pointer `*const u8`
               found raw pointer `*const i8
```
