### PR TITLE
Separate tun queue fd from interface accessors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ mod tun;
 pub mod result;
 
 pub use self::builder::TunBuilder;
-pub use self::tun::Tun;
+pub use self::tun::{Tun, TunQueue};

--- a/src/linux/io.rs
+++ b/src/linux/io.rs
@@ -1,6 +1,6 @@
 use std::convert::From;
 use std::io::{self, Read, Write};
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
 pub struct TunIo(RawFd);
 
@@ -13,6 +13,12 @@ impl From<RawFd> for TunIo {
 impl FromRawFd for TunIo {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self(fd)
+    }
+}
+
+impl IntoRawFd for TunIo {
+    fn into_raw_fd(self) -> RawFd {
+        self.0
     }
 }
 


### PR DESCRIPTION
This change supports applications that want to receive or pass a tun device's file descriptor to another (possibly less privileged) application and have it usable by tokio-tun on the other side.

The alternative is to open a multiqueue tun device and temporarily open additional queues, which has a disruptive impact on existing flows received on the tun device.

This change resolves #17.