### PR TITLE
Add feature to set / get TAP MAC address

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,5 @@
 use super::result::Result;
+use crate::linux::address::MACAddr;
 #[cfg(target_os = "linux")]
 use crate::linux::params::Params;
 #[cfg(target_os = "linux")]
@@ -17,6 +18,7 @@ pub struct TunBuilder<'a> {
     mtu: Option<i32>,
     owner: Option<i32>,
     group: Option<i32>,
+    mac_address: Option<MACAddr>,
     address: Option<Ipv4Addr>,
     destination: Option<Ipv4Addr>,
     broadcast: Option<Ipv4Addr>,
@@ -34,6 +36,7 @@ impl<'a> Default for TunBuilder<'a> {
             up: false,
             mtu: None,
             packet_info: true,
+            mac_address: None,
             address: None,
             destination: None,
             broadcast: None,
@@ -104,6 +107,14 @@ impl<'a> TunBuilder<'a> {
     /// This is the numeric GID of the group that will own the created device.
     pub fn group(mut self, group: i32) -> Self {
         self.group = Some(group);
+        self
+    }
+
+    /// Sets MAC address of device.
+    ///
+    /// This manually specifies the MAC address that will be associated with the created device.
+    pub fn mac_address(mut self, address: MACAddr) -> Self {
+        self.mac_address = Some(address);
         self
     }
 
@@ -197,6 +208,7 @@ impl<'a> From<TunBuilder<'a>> for Params {
             mtu: builder.mtu,
             owner: builder.owner,
             group: builder.group,
+            mac_address: builder.mac_address,
             address: builder.address,
             destination: builder.destination,
             broadcast: builder.broadcast,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -113,8 +113,8 @@ impl<'a> TunBuilder<'a> {
     /// Sets MAC address of device.
     ///
     /// This manually specifies the MAC address that will be associated with the created device.
-    pub fn mac_address(mut self, address: MACAddr) -> Self {
-        self.mac_address = Some(address);
+    pub fn mac_address(mut self, address: [u8; 6]) -> Self {
+        self.mac_address = Some(MACAddr::new(address));
         self
     }
 

--- a/src/linux/address.rs
+++ b/src/linux/address.rs
@@ -22,6 +22,11 @@ impl MACAddr {
         Self { data }
     }
 }
+impl Into<[u8; 6]> for MACAddr {
+    fn into(self) -> [u8; 6] {
+        self.data
+    }
+}
 
 
 fn hton(octets: [u8; 4]) -> u32 {

--- a/src/linux/address.rs
+++ b/src/linux/address.rs
@@ -7,6 +7,18 @@ pub trait Ipv4AddrExt {
     fn from_address(sock: sockaddr) -> Self;
 }
 
+// Ext suffix is in case a dependency on an external MAC address crate is ever pulled in
+// Also matches above naming this way
+pub trait MACAddrExt {
+    fn to_address(&self) -> sockaddr;
+    fn from_address(sock: sockaddr) -> Self;
+}
+
+pub struct MACAddr {
+    data: [u8; 6],
+}
+
+
 fn hton(octets: [u8; 4]) -> u32 {
     (octets[3] as u32) << 24 | (octets[2] as u32) << 16 | (octets[1] as u32) << 8 | octets[0] as u32
 }
@@ -34,5 +46,24 @@ impl Ipv4AddrExt for Ipv4Addr {
     fn from_address(addr: sockaddr) -> Self {
         let sock: libc::sockaddr_in = unsafe { mem::transmute(addr) };
         ntoh(sock.sin_addr.s_addr).into()
+    }
+}
+
+impl MACAddrExt for MACAddr {
+    fn to_address(&self) -> sockaddr {
+        let mut addr: sockaddr = unsafe { mem::zeroed() };
+        addr.sa_family = libc::ARPHRD_ETHER;
+        for i in 0..6 {
+            addr.sa_data[i] = self.data[i] as libc::c_char;
+        }
+        addr
+    }
+
+    fn from_address(sock: sockaddr) -> Self {
+        let mut mac = Self { data: [0; 6] };
+        for i in 0..6 {
+            mac.data[i] = sock.sa_data[i] as u8;
+        }
+        mac
     }
 }

--- a/src/linux/address.rs
+++ b/src/linux/address.rs
@@ -17,6 +17,11 @@ pub trait MACAddrExt {
 pub struct MACAddr {
     data: [u8; 6],
 }
+impl MACAddr {
+    pub fn new(data: [u8; 6]) -> Self {
+        Self { data }
+    }
+}
 
 
 fn hton(octets: [u8; 4]) -> u32 {

--- a/src/linux/interface.rs
+++ b/src/linux/interface.rs
@@ -1,3 +1,4 @@
+use super::address::{MACAddr, MACAddrExt};
 use super::params::Params;
 use super::request::ifreq;
 use crate::linux::address::Ipv4AddrExt;
@@ -15,6 +16,7 @@ nix::ioctl_write_ptr_bad!(siocsifaddr, libc::SIOCSIFADDR, ifreq);
 nix::ioctl_write_ptr_bad!(siocsifdstaddr, libc::SIOCSIFDSTADDR, ifreq);
 nix::ioctl_write_ptr_bad!(siocsifbrdaddr, libc::SIOCSIFBRDADDR, ifreq);
 nix::ioctl_write_ptr_bad!(siocsifnetmask, libc::SIOCSIFNETMASK, ifreq);
+nix::ioctl_write_ptr_bad!(siocsifhwaddr, libc::SIOCSIFHWADDR, ifreq);
 
 nix::ioctl_read_bad!(siocgifmtu, libc::SIOCGIFMTU, ifreq);
 nix::ioctl_read_bad!(siocgifflags, libc::SIOCGIFFLAGS, ifreq);
@@ -22,6 +24,7 @@ nix::ioctl_read_bad!(siocgifaddr, libc::SIOCGIFADDR, ifreq);
 nix::ioctl_read_bad!(siocgifdstaddr, libc::SIOCGIFDSTADDR, ifreq);
 nix::ioctl_read_bad!(siocgifbrdaddr, libc::SIOCGIFBRDADDR, ifreq);
 nix::ioctl_read_bad!(siocgifnetmask, libc::SIOCGIFNETMASK, ifreq);
+nix::ioctl_read_bad!(siocgifhwaddr, libc::SIOCGIFHWADDR, ifreq);
 
 #[derive(Clone)]
 pub struct Interface {
@@ -56,6 +59,9 @@ impl Interface {
         }
         if let Some(group) = params.group {
             self.group(group)?;
+        }
+        if let Some(mac_address) = params.mac_address {
+            self.mac_address(Some(mac_address))?;
         }
         if let Some(address) = params.address {
             self.address(Some(address))?;
@@ -106,6 +112,17 @@ impl Interface {
         }
         unsafe { siocgifnetmask(self.socket, &mut req) }?;
         Ok(unsafe { Ipv4Addr::from_address(req.ifr_ifru.ifru_netmask) })
+    }
+
+    pub fn mac_address(&self, mac: Option<MACAddr>) -> Result<MACAddr> {
+        let mut req = ifreq::new(self.name());
+        if let Some(mac) = mac {
+            req.ifr_ifru.ifru_hwaddr = mac.to_address();
+            unsafe { siocsifhwaddr(self.socket, &req) }?;
+            return Ok(mac);
+        }
+        unsafe { siocgifhwaddr(self.socket, &mut req) }?;
+        Ok(unsafe { MACAddr::from_address(req.ifr_ifru.ifru_hwaddr) })
     }
 
     pub fn address(&self, address: Option<Ipv4Addr>) -> Result<Ipv4Addr> {

--- a/src/linux/params.rs
+++ b/src/linux/params.rs
@@ -1,5 +1,7 @@
 use std::net::Ipv4Addr;
 
+use super::address::MACAddr;
+
 /// Represents parameters for creating a new Tun/Tap device on Linux.
 #[cfg(target_os = "linux")]
 pub struct Params {
@@ -10,6 +12,7 @@ pub struct Params {
     pub mtu: Option<i32>,
     pub owner: Option<i32>,
     pub group: Option<i32>,
+    pub mac_address: Option<MACAddr>,
     pub address: Option<Ipv4Addr>,
     pub destination: Option<Ipv4Addr>,
     pub broadcast: Option<Ipv4Addr>,

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -193,6 +193,10 @@ impl Tun {
         self.iface.mtu(None)
     }
 
+    pub fn mac_address(&self) -> Result<[u8; 6]> {
+        Ok(self.iface.mac_address(None)?.into())
+    }
+
     /// Returns the IPv4 address of MTU.
     pub fn address(&self) -> Result<Ipv4Addr> {
         self.iface.address(None)


### PR DESCRIPTION
This pull request adds support for setting and getting the MAC address of the tun/tap device using the `SIOCSIFHWADDR` ioctl. 

I have verified that it works with a TAP device. When attempting to set the MAC address of a TUN device, `TunBuilder::try_build` will return an error (`EOPNOTSUPP`). Let me know if this is an undesirable failure mode.