### PR TITLE
Check that opening /dev/net/tun is ok

### DIFF
--- a/src/tun.rs
+++ b/src/tun.rs
@@ -126,12 +126,17 @@ impl Tun {
 
         let fds = (0..queues)
             .map(|_| unsafe {
-                libc::open(
+                let fd = libc::open(
                     TUN.as_ptr().cast::<c_char>(),
                     libc::O_RDWR | libc::O_NONBLOCK,
-                )
+                );
+                if fd < 0 {
+                    Err(std::io::Error::last_os_error().into())
+                } else {
+                    Ok(fd)
+                }
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
 
         let iface = Interface::new(
             fds,


### PR DESCRIPTION
Currently the allocate function ignores the open error. Check the file descriptor return value and return an std::io::Error when it fails to return a real FD.