### PR TITLE
Separate tun queue fd from interface accessors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ mod tun;
 
 pub use self::builder::TunBuilder;
 pub use self::result::{Error, Result};
-pub use self::tun::Tun;
+pub use self::tun::{Tun, TunQueue};

--- a/src/linux/io.rs
+++ b/src/linux/io.rs
@@ -1,6 +1,6 @@
 use std::convert::From;
 use std::io::{self, IoSlice, Read, Write};
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 
 pub struct TunIo(RawFd);
 
@@ -13,6 +13,12 @@ impl From<RawFd> for TunIo {
 impl FromRawFd for TunIo {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         Self(fd)
+    }
+}
+
+impl IntoRawFd for TunIo {
+    fn into_raw_fd(self) -> RawFd {
+        self.0
     }
 }
 

--- a/src/tun.rs
+++ b/src/tun.rs
@@ -7,7 +7,7 @@ use std::io::{self, ErrorKind, IoSlice, Read, Write};
 use std::mem;
 use std::net::Ipv4Addr;
 use std::os::raw::c_char;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{self, Context, Poll};
@@ -29,7 +29,7 @@ macro_rules! ready {
 /// Represents a Tun/Tap device. Use [`TunBuilder`](struct.TunBuilder.html) to create a new instance of [`Tun`](struct.Tun.html).
 pub struct Tun {
     iface: Arc<Interface>,
-    io: AsyncFd<TunIo>,
+    io: TunQueue,
 }
 
 impl AsRawFd for Tun {
@@ -44,19 +44,7 @@ impl AsyncRead for Tun {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> task::Poll<io::Result<()>> {
-        let self_mut = self.get_mut();
-        loop {
-            let mut guard = ready!(self_mut.io.poll_read_ready_mut(cx))?;
-
-            match guard.try_io(|inner| inner.get_mut().read(buf.initialize_unfilled())) {
-                Ok(Ok(n)) => {
-                    buf.set_filled(buf.filled().len() + n);
-                    return Poll::Ready(Ok(()));
-                }
-                Ok(Err(err)) => return Poll::Ready(Err(err)),
-                Err(_) => continue,
-            }
-        }
+        Pin::new(&mut self.get_mut().io).poll_read(cx, buf)
     }
 }
 
@@ -66,15 +54,7 @@ impl AsyncWrite for Tun {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> task::Poll<io::Result<usize>> {
-        let self_mut = self.get_mut();
-        loop {
-            let mut guard = ready!(self_mut.io.poll_write_ready_mut(cx))?;
-
-            match guard.try_io(|inner| inner.get_mut().write(buf)) {
-                Ok(result) => return Poll::Ready(result),
-                Err(_would_block) => continue,
-            }
-        }
+        Pin::new(&mut self.get_mut().io).poll_write(cx, buf)
     }
 
     fn poll_write_vectored(
@@ -82,15 +62,7 @@ impl AsyncWrite for Tun {
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
     ) -> Poll<std::result::Result<usize, io::Error>> {
-        let self_mut = self.get_mut();
-        loop {
-            let mut guard = ready!(self_mut.io.poll_write_ready_mut(cx))?;
-
-            match guard.try_io(|inner| inner.get_mut().write_vectored(bufs)) {
-                Ok(result) => return Poll::Ready(result),
-                Err(_would_block) => continue,
-            }
-        }
+        Pin::new(&mut self.get_mut().io).poll_write_vectored(cx, bufs)
     }
 
     fn is_write_vectored(&self) -> bool {
@@ -98,19 +70,11 @@ impl AsyncWrite for Tun {
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> task::Poll<io::Result<()>> {
-        let self_mut = self.get_mut();
-        loop {
-            let mut guard = ready!(self_mut.io.poll_write_ready_mut(cx))?;
-
-            match guard.try_io(|inner| inner.get_mut().flush()) {
-                Ok(result) => return Poll::Ready(result),
-                Err(_) => continue,
-            }
-        }
+        Pin::new(&mut self.get_mut().io).poll_flush(cx)
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> task::Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> task::Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().io).poll_shutdown(cx)
     }
 }
 
@@ -125,7 +89,7 @@ impl Tun {
         let fd = iface.files()[0];
         Ok(Self {
             iface: Arc::new(iface),
-            io: AsyncFd::new(TunIo::from(fd))?,
+            io: TunQueue::new(fd)?,
         })
     }
 
@@ -137,7 +101,7 @@ impl Tun {
         for &fd in iface.files() {
             tuns.push(Self {
                 iface: iface.clone(),
-                io: AsyncFd::new(TunIo::from(fd))?,
+                io: TunQueue::new(fd)?,
             })
         }
         Ok(tuns)
@@ -169,56 +133,28 @@ impl Tun {
     ///
     /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
     pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        loop {
-            let mut guard = self.io.readable().await?;
-            match guard.try_io(|inner| inner.get_ref().recv(buf)) {
-                Ok(res) => return res,
-                Err(_) => continue,
-            }
-        }
+        self.io.recv(buf).await
     }
 
     /// Sends a buffer to the Tun/Tap interface. Returns the number of bytes written to the device.
     ///
     /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
     pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        loop {
-            let mut guard = self.io.writable().await?;
-            match guard.try_io(|inner| inner.get_ref().send(buf)) {
-                Ok(res) => return res,
-                Err(_) => continue,
-            }
-        }
+        self.io.send(buf).await
     }
 
     /// Sends all of a buffer to the Tun/Tap interface.
     ///
     /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
     pub async fn send_all(&self, buf: &[u8]) -> io::Result<()> {
-        let mut remaining = buf;
-        while !remaining.is_empty() {
-            match self.send(remaining).await? {
-                0 => return Err(ErrorKind::WriteZero.into()),
-                n => {
-                    let (_, rest) = mem::take(&mut remaining).split_at(n);
-                    remaining = rest;
-                }
-            }
-        }
-        Ok(())
+        self.io.send_all(buf).await
     }
 
     /// Sends several different buffers to the Tun/Tap interface. Returns the number of bytes written to the device.
     ///
     /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
     pub async fn send_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        loop {
-            let mut guard = self.io.writable().await?;
-            match guard.try_io(|inner| inner.get_ref().sendv(bufs)) {
-                Ok(res) => return res,
-                Err(_) => continue,
-            }
-        }
+        self.io.send_vectored(bufs).await
     }
 
     /// Tries to receive a buffer from the Tun/Tap interface.
@@ -227,7 +163,7 @@ impl Tun {
     ///
     /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
     pub fn try_recv(&self, buf: &mut [u8]) -> io::Result<usize> {
-        self.io.get_ref().recv(buf)
+        self.io.try_recv(buf)
     }
 
     /// Tries to send a packet to the Tun/Tap interface.
@@ -236,7 +172,7 @@ impl Tun {
     ///
     /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
     pub fn try_send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.io.get_ref().send(buf)
+        self.io.try_send(buf)
     }
 
     /// Tries to send several different buffers to the Tun/Tap interface.
@@ -245,7 +181,7 @@ impl Tun {
     ///
     /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
     pub fn try_send_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        self.io.get_ref().sendv(bufs)
+        self.io.try_send_vectored(bufs)
     }
 
     /// Returns the name of Tun/Tap device.
@@ -281,5 +217,193 @@ impl Tun {
     /// Returns the flags of MTU.
     pub fn flags(&self) -> Result<i16> {
         self.iface.flags(None)
+    }
+}
+
+/// Represents a queue of a Tun/Tap device.
+pub struct TunQueue(AsyncFd<TunIo>);
+
+impl IntoRawFd for TunQueue {
+    fn into_raw_fd(self) -> RawFd {
+        self.0.into_inner().into_raw_fd()
+    }
+}
+
+impl AsRawFd for TunQueue {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl From<Tun> for TunQueue {
+    fn from(tun: Tun) -> Self {
+        tun.io
+    }
+}
+
+impl AsyncRead for TunQueue {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> task::Poll<io::Result<()>> {
+        let self_mut = self.get_mut();
+        loop {
+            let mut guard = ready!(self_mut.0.poll_read_ready_mut(cx))?;
+
+            match guard.try_io(|inner| inner.get_mut().read(buf.initialize_unfilled())) {
+                Ok(Ok(n)) => {
+                    buf.set_filled(buf.filled().len() + n);
+                    return Poll::Ready(Ok(()));
+                }
+                Ok(Err(err)) => return Poll::Ready(Err(err)),
+                Err(_) => continue,
+            }
+        }
+    }
+}
+
+impl AsyncWrite for TunQueue {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> task::Poll<io::Result<usize>> {
+        let self_mut = self.get_mut();
+        loop {
+            let mut guard = ready!(self_mut.0.poll_write_ready_mut(cx))?;
+
+            match guard.try_io(|inner| inner.get_mut().write(buf)) {
+                Ok(result) => return Poll::Ready(result),
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<std::result::Result<usize, io::Error>> {
+        let self_mut = self.get_mut();
+        loop {
+            let mut guard = ready!(self_mut.0.poll_write_ready_mut(cx))?;
+
+            match guard.try_io(|inner| inner.get_mut().write_vectored(bufs)) {
+                Ok(result) => return Poll::Ready(result),
+                Err(_would_block) => continue,
+            }
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> task::Poll<io::Result<()>> {
+        let self_mut = self.get_mut();
+        loop {
+            let mut guard = ready!(self_mut.0.poll_write_ready_mut(cx))?;
+
+            match guard.try_io(|inner| inner.get_mut().flush()) {
+                Ok(result) => return Poll::Ready(result),
+                Err(_) => continue,
+            }
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> task::Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl TunQueue {
+    pub fn new<T: AsRawFd>(inner: T) -> io::Result<Self> {
+        Ok(TunQueue(AsyncFd::new(TunIo::from(inner.as_raw_fd()))?))
+    }
+
+    /// Receives a packet from the Tun/Tap interface
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.0.readable().await?;
+
+            match guard.try_io(|inner| inner.get_ref().recv(buf)) {
+                Ok(res) => return res,
+                Err(_) => continue,
+            }
+        }
+    }
+
+    /// Sends a packet to the Tun/Tap interface
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.0.writable().await?;
+
+            match guard.try_io(|inner| inner.get_ref().send(buf)) {
+                Ok(res) => return res,
+                Err(_) => continue,
+            }
+        }
+    }
+
+    /// Sends all of a buffer to the Tun/Tap interface.
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub async fn send_all(&self, buf: &[u8]) -> io::Result<()> {
+        let mut remaining = buf;
+        while !remaining.is_empty() {
+            match self.send(remaining).await? {
+                0 => return Err(ErrorKind::WriteZero.into()),
+                n => {
+                    let (_, rest) = mem::take(&mut remaining).split_at(n);
+                    remaining = rest;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Sends several different buffers to the Tun/Tap interface. Returns the number of bytes written to the device.
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub async fn send_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        loop {
+            let mut guard = self.0.writable().await?;
+            match guard.try_io(|inner| inner.get_ref().sendv(bufs)) {
+                Ok(res) => return res,
+                Err(_) => continue,
+            }
+        }
+    }
+
+    /// Try to receive a packet from the Tun/Tap interface
+    ///
+    /// When there is no pending data, `Err(io::ErrorKind::WouldBlock)` is returned.
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub fn try_recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.get_ref().recv(buf)
+    }
+
+    /// Try to send a packet to the Tun/Tap interface
+    ///
+    /// When the socket buffer is full, `Err(io::ErrorKind::WouldBlock)` is returned.
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub fn try_send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.0.get_ref().send(buf)
+    }
+
+    /// Tries to send several different buffers to the Tun/Tap interface.
+    ///
+    /// When the socket buffer is full, `Err(io::ErrorKind::WouldBlock)` is returned.
+    ///
+    /// This method takes &self, so it is possible to call this method concurrently with other methods on this struct.
+    pub fn try_send_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        self.0.get_ref().sendv(bufs)
     }
 }


### PR DESCRIPTION
This change supports applications that want to receive or pass a tun device's file descriptor to another (possibly less privileged) application and have it usable by tokio-tun on the other side.

The alternative is to open a multiqueue tun device and temporarily open additional queues, which has a disruptive impact on existing flows received on the tun device.

This change resolves #17.

----


I did not author this commit but I work with the author and got permission to drive getting it upstreamed. 
 This is https://github.com/yaa110/tokio-tun/pull/18 but rebased on top of main. 

CC: @cbranch