### PR TITLE
Open multiqueue tun device even with 1 queue

### DIFF
--- a/src/linux/interface.rs
+++ b/src/linux/interface.rs
@@ -31,9 +31,9 @@ pub struct Interface {
 }
 
 impl Interface {
-    pub fn new(fds: Vec<i32>, name: &str, mut flags: i16) -> Result<Self> {
+    pub fn new(fds: Vec<i32>, name: &str, mut flags: i16, multi_queue: bool) -> Result<Self> {
         let mut req = ifreq::new(name);
-        if fds.len() > 1 {
+        if multi_queue {
             flags |= libc::IFF_MULTI_QUEUE as i16;
         }
         req.ifr_ifru.ifru_flags = flags;


### PR DESCRIPTION
Make the use of the IFF_MULTI_QUEUE flag independent of the number of queues actually requested.

It is possible and valid to open a tun device in multiqueue mode but still open only one queue e.g. if the tunnel device was created for you as multiqueue but you only want to access it on a single thread, or if you want to open more queues later.

----


I did not author this commit but I work with the author and got permission to drive getting it upstreamed. 
 This is https://github.com/yaa110/tokio-tun/pull/19 but rebased on top of main. 

CC: @cbranch