### PR TITLE
Fix compilation on Android

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 use crate::Result;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use crate::linux::params::Params;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use crate::tun::Tun;
 use core::convert::From;
 use libc::{IFF_NO_PI, IFF_TAP, IFF_TUN};
@@ -184,7 +184,7 @@ impl TunBuilder {
 }
 
 impl From<TunBuilder> for Params {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn from(builder: TunBuilder) -> Self {
         Params {
             name: if builder.name.is_empty() {
@@ -211,7 +211,7 @@ impl From<TunBuilder> for Params {
         }
     }
 
-    #[cfg(not(any(target_os = "linux")))]
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
     fn from(builder: TunBuilder) -> Self {
         unimplemented!()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux {
     pub mod address;
     pub mod interface;

--- a/src/linux/params.rs
+++ b/src/linux/params.rs
@@ -1,7 +1,7 @@
 use std::net::Ipv4Addr;
 
 /// Represents parameters for creating a new Tun/Tap device on Linux.
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub struct Params {
     pub name: Option<String>,
     pub flags: i16,


### PR DESCRIPTION
This PR extends all `target_os` conditionals to include the `android` target.
This enables compilation of the crate on the Android platform (e.g. in `termux`).