### PR TITLE
set CLOEXEC flags to all open sockets

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,6 +22,7 @@ pub struct TunBuilder {
     broadcast: Option<Ipv4Addr>,
     netmask: Option<Ipv4Addr>,
     queues: Option<usize>,
+    cloexec: bool,
 }
 
 impl Default for TunBuilder {
@@ -40,6 +41,7 @@ impl Default for TunBuilder {
             broadcast: None,
             netmask: None,
             queues: None,
+            cloexec: true,
         }
     }
 }
@@ -152,6 +154,14 @@ impl TunBuilder {
         self
     }
 
+    /// Removes CLOEXEC flag on all FDs. This will allow passing tun/tap FDs to any exec-ed
+    /// child processes.
+    /// Default behaviour is to prevent passing fds flag.
+    pub fn no_close_on_exec(mut self) -> Self {
+        self.cloexec = false;
+        self
+    }
+
     /// Makes the device persistent.
     ///
     /// Persistent devices stay registered as long as the computer is not restarted.
@@ -208,6 +218,7 @@ impl From<TunBuilder> for Params {
             destination: builder.destination,
             broadcast: builder.broadcast,
             netmask: builder.netmask,
+            cloexec: builder.cloexec,
         }
     }
 

--- a/src/linux/interface.rs
+++ b/src/linux/interface.rs
@@ -31,7 +31,8 @@ pub struct Interface {
 }
 
 impl Interface {
-    pub fn new(fds: Vec<i32>, name: &str, mut flags: i16) -> Result<Self> {
+    pub fn new(fds: Vec<i32>, name: &str, mut flags: i16, cloexec: bool) -> Result<Self> {
+        let extra_flags = if cloexec { libc::O_CLOEXEC } else { 0 };
         let mut req = ifreq::new(name);
         if fds.len() > 1 {
             flags |= libc::IFF_MULTI_QUEUE as i16;
@@ -42,7 +43,7 @@ impl Interface {
         }
         Ok(Interface {
             fds,
-            socket: unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) },
+            socket: unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM | extra_flags, 0) },
             name: req.name().to_owned(),
         })
     }

--- a/src/linux/params.rs
+++ b/src/linux/params.rs
@@ -14,4 +14,5 @@ pub struct Params {
     pub destination: Option<Ipv4Addr>,
     pub broadcast: Option<Ipv4Addr>,
     pub netmask: Option<Ipv4Addr>,
+    pub cloexec: bool,
 }


### PR DESCRIPTION
This prevents sockets from leaking to child processes.
